### PR TITLE
fix: install CMake config in subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,10 +60,10 @@ configure_package_config_file(
   "${PROJECT_BINARY_DIR}/libcommuteConfig.cmake"
   INSTALL_DESTINATION lib/cmake
 )
-install(EXPORT libcommuteTargets DESTINATION lib/cmake)
+install(EXPORT libcommuteTargets DESTINATION lib/cmake/libcommute)
 install(FILES "${PROJECT_BINARY_DIR}/libcommuteConfigVersion.cmake"
               "${PROJECT_BINARY_DIR}/libcommuteConfig.cmake"
-        DESTINATION lib/cmake)
+        DESTINATION lib/cmake/libcommute)
 
 # Install pkg-config file
 configure_file(libcommute.pc.in libcommute.pc @ONLY)


### PR DESCRIPTION
By default CMake searches for configuration files in subdirectories with the same name as the package it's trying to find.

See also: https://cliutils.gitlab.io/modern-cmake/chapters/install/installing.html